### PR TITLE
feat: add `active` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Because event modifiers cannot be used on Svelte components, use the mouse event
 
 ```svelte
 <Link href="https://github.com/" outbound>GitHub</Link>
-<!-- is the same as -->
+
+<!-- same as -->
+
 <Link href="https://github.com/" target="_blank" rel="noopener noreferrer">
   GitHub
 </Link>
@@ -77,13 +79,30 @@ Inspired by [Sapper](https://sapper.svelte.dev/docs#prefetch_href), if the non-s
 <Link href="/about" rel="prefetch">About</Link>
 ```
 
-### Disabled
+### Disabled state
 
 Setting `disabled` to `true` will render a `span` element instead of an anchor tag.
 
 ```svelte
 <Link disabled href="https://github.com/">GitHub</Link>
+
 <!-- <span>GitHub</span> -->
+```
+
+### Active state
+
+Set `active` to `true` to signal an active state.
+
+If `true`, the anchor link is given an "active" class with the `aria-current` attribute set to "page."
+
+```svelte no-eval
+<script>
+  import { page } from "$app/stores";
+</script>
+
+<Link href="/" active={$page.url.pathname === "/"}>GitHub</Link>
+
+<!-- <a href="/" class="active" aria-current="page">GitHub</a> -->
 ```
 
 ## API
@@ -97,6 +116,7 @@ Setting `disabled` to `true` will render a `span` element instead of an anchor t
 | outbound | `boolean` | `undefined`             |
 | target   | `string`  | `undefined`             |
 | rel      | `string`  | `undefined`             |
+| active   | `boolean` | `false`                 |
 
 ### Forwarded events
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "svelte": "^3.46.2",
-    "svelte-check": "^2.3.0",
+    "svelte": "^3.46.4",
+    "svelte-check": "^2.4.5",
     "svelte-readme": "^3.6.2"
   },
   "repository": {

--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -32,6 +32,13 @@
    */
   export let rel = undefined;
 
+  /**
+   * Set to `true` for the link to be active:
+   * - link is given an "active" class
+   * - `aria-current` is set to "page"
+   */
+  export let active = false;
+
   async function prefetch() {
     if (fetched.has(href)) return;
     const response = await fetch(href);
@@ -69,6 +76,8 @@
   </span>
 {:else}
   <a
+    class:active
+    aria-current={active ? "page" : undefined}
     {...$$restProps}
     {href}
     {target}

--- a/test/Link.test.svelte
+++ b/test/Link.test.svelte
@@ -7,6 +7,7 @@
   outbound={false}
   disabled={false}
   target="_blank"
+  active
   rel=""
   href="https://github.com/"
   on:click={(e) => {

--- a/types/Link.svelte.d.ts
+++ b/types/Link.svelte.d.ts
@@ -36,6 +36,14 @@ export interface LinkProps
    * @default undefined
    */
   rel?: string;
+
+  /**
+   * Set to `true` for the link to be active:
+   * - link is given an "active" class
+   * - `aria-current` is set to "page"
+   * @default false
+   */
+  active?: boolean;
 }
 
 export default class Link extends SvelteComponentTyped<

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,10 +808,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-svelte-check@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-2.3.0.tgz#3969e3c0655427d79f6251c1f9c05896eb07cf59"
-  integrity sha512-SBKdJyUmxzPmJf/ZPqDSQOoa9JzOcgEpV7u3UaYcgVn7fA0veZ3FA5JgLU8KYtf84Gp6guBVcrC7XKLjJa5SXQ==
+svelte-check@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-2.4.5.tgz#a2001993034d495118980bd95577fb3e7980661a"
+  integrity sha512-nRft8BbG2wcxyCdHDZ7X43xLcvDzua3xLwq6wzHGcAF3ka3Jyhv2rvgq0+SF9NwHLMefp9C2XkM6etzsxK/cMQ==
   dependencies:
     chokidar "^3.4.1"
     fast-glob "^3.2.7"
@@ -855,10 +855,10 @@ svelte-readme@^3.6.2:
     rollup-plugin-svelte "^7.0.0"
     rollup-plugin-terser "^7.0.2"
 
-svelte@^3.46.2:
-  version "3.46.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.2.tgz#f0ffbffaea3a9a760edcbefc0902b41998a686ad"
-  integrity sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==
+svelte@^3.46.4:
+  version "3.46.4"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.4.tgz#0c46bc4a3e20a2617a1b7dc43a722f9d6c084a38"
+  integrity sha512-qKJzw6DpA33CIa+C/rGp4AUdSfii0DOTCzj/2YpSKKayw5WGSS624Et9L1nU1k2OVRS9vaENQXp2CVZNU+xvIg==
 
 terser@^5.0.0:
   version "5.10.0"


### PR DESCRIPTION
Closes #13 

Set `active` to `true` to signal an active state.

If `true`, the anchor link is given an "active" class with the `aria-current` attribute set to "page."

```svelte no-eval
<script>
  import { page } from "$app/stores";
</script>

<Link href="/" active={$page.url.pathname === "/"}>GitHub</Link>
```

Rendered output:

```html
<a href="/" class="active" aria-current="page">GitHub</a>
```