### PR TITLE
feat(types): add `sveltekit:reload` attribute to TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@testing-library/svelte": "^3.1.1",
     "jsdom": "^19.0.0",
     "svelte": "^3.47.0",
-    "svelte-check": "^2.6.0",
+    "svelte-check": "^2.7.0",
     "svelte-readme": "^3.6.3",
     "vitest": "^0.9.3"
   },

--- a/src/Link.svelte.d.ts
+++ b/src/Link.svelte.d.ts
@@ -54,9 +54,17 @@ export interface LinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,10 +1476,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-svelte-check@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-2.6.0.tgz#ddb590236a9f78a0a7ffa80d9de6460432003b57"
-  integrity sha512-POL3IqLUuGqb9DdvuXQaSTNXYnw/odK4hqW86+2LwGcZTdbUPKBBln7pq74wXmcnRE+12bXMY1CvbcUNa2d5nw==
+svelte-check@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-2.7.0.tgz#10d579dc89bf2e145a04786cc9fa8dabfb018a2a"
+  integrity sha512-GrvG24j0+i8AOm0k0KyJ6Dqc+TAR2yzB7rtS4nljHStunVxCTr/1KYlv4EsOeoqtHLzeWMOd5D2O6nDdP/yw4A==
   dependencies:
     chokidar "^3.4.1"
     fast-glob "^3.2.7"


### PR DESCRIPTION
SvelteKit supports a `sveltekit:reload` attribute for anchor links.